### PR TITLE
refactor(atom_typing): replace private _adjacency access with get_neighbor_bonds() API

### DIFF
--- a/src/services/forcefield/atom_typing/hand_coded.py
+++ b/src/services/forcefield/atom_typing/hand_coded.py
@@ -94,13 +94,12 @@ class HandCodedAtomTyper:
         has_triple = False
         double_neighbor_syms = []
         for n_idx in neighbors:
-            for nb_other, bond_idx in mol._adjacency[atom.index]:
+            for nb_other, bond in mol.get_neighbor_bonds(atom.index):
                 if nb_other == n_idx:
-                    order = mol.bonds[bond_idx].order
-                    if order == 2:
+                    if bond.order == 2:
                         has_double = True
                         double_neighbor_syms.append(mol.atoms[n_idx].symbol)
-                    elif order == 3:
+                    elif bond.order == 3:
                         has_triple = True
 
         # Type 4: alkyne (sp C with triple bond).
@@ -169,8 +168,8 @@ class HandCodedAtomTyper:
         # Determine double bonds + bond-order details.
         has_double_to = []  # list of (symbol) per double-bond
         for n_idx in neighbors:
-            for nb_other, bond_idx in mol._adjacency[atom.index]:
-                if nb_other == n_idx and mol.bonds[bond_idx].order == 2:
+            for nb_other, bond in mol.get_neighbor_bonds(atom.index):
+                if nb_other == n_idx and bond.order == 2:
                     has_double_to.append(mol.atoms[n_idx].symbol)
                     break
 
@@ -189,9 +188,9 @@ class HandCodedAtomTyper:
         for na in neighbor_atoms:
             if na.symbol == "C":
                 # Check if that C has a =O
-                for c_nb, c_bond_idx in mol._adjacency[na.index]:
+                for c_nb, c_bond in mol.get_neighbor_bonds(na.index):
                     if (mol.atoms[c_nb].symbol == "O"
-                            and mol.bonds[c_bond_idx].order == 2):
+                            and c_bond.order == 2):
                         return (10, 10)
 
         # Type 9: imine N (sp2 N with =C).
@@ -224,8 +223,8 @@ class HandCodedAtomTyper:
         # Determine if double-bonded.
         has_double = False
         for n_idx in neighbors:
-            for nb_other, bond_idx in mol._adjacency[atom.index]:
-                if nb_other == n_idx and mol.bonds[bond_idx].order == 2:
+            for nb_other, bond in mol.get_neighbor_bonds(atom.index):
+                if nb_other == n_idx and bond.order == 2:
                     has_double = True
                     break
             if has_double:
@@ -257,8 +256,8 @@ class HandCodedAtomTyper:
         n_double_o = 0
         n_double_other = 0
         for n_idx in neighbors:
-            for nb_other, bond_idx in mol._adjacency[atom.index]:
-                if nb_other == n_idx and mol.bonds[bond_idx].order == 2:
+            for nb_other, bond in mol.get_neighbor_bonds(atom.index):
+                if nb_other == n_idx and bond.order == 2:
                     if mol.atoms[n_idx].symbol == "O":
                         n_double_o += 1
                     else:
@@ -284,8 +283,8 @@ class HandCodedAtomTyper:
         # Count =O double bonds.
         n_double_o = 0
         for n_idx in mol.get_neighbors(atom.index):
-            for nb_other, bond_idx in mol._adjacency[atom.index]:
-                if nb_other == n_idx and mol.bonds[bond_idx].order == 2:
+            for nb_other, bond in mol.get_neighbor_bonds(atom.index):
+                if nb_other == n_idx and bond.order == 2:
                     if mol.atoms[n_idx].symbol == "O":
                         n_double_o += 1
 


### PR DESCRIPTION
## Summary

Resolves vijaymasand/PyChem-Pro#5

Replaces all **6 instances** of direct `mol._adjacency[...]` access in `hand_coded.py` with the public `mol.get_neighbor_bonds()` API, eliminating an encapsulation violation that couples the atom typer to `Molecule`'s internal graph storage.

## Changes

**File:** `src/services/forcefield/atom_typing/hand_coded.py`

| Method | Change |
|---|---|
| `_type_carbon` | `_adjacency[atom.index]` → `get_neighbor_bonds(atom.index)` |
| `_type_nitrogen` (×2) | `_adjacency[atom.index]` and `_adjacency[na.index]` → public API |
| `_type_oxygen` | `_adjacency[atom.index]` → `get_neighbor_bonds(atom.index)` |
| `_type_sulfur` | `_adjacency[atom.index]` → `get_neighbor_bonds(atom.index)` |
| `_type_phosphorus` | `_adjacency[atom.index]` → `get_neighbor_bonds(atom.index)` |

Unpacking updated from `(nb, bond_idx)` + `mol.bonds[bond_idx].order` to `(nb, bond)` + `bond.order`. Zero behavioral change.

## Testing

I wrote a local regression suite with 3 tests:

1. **Functional** — verifies correct `mmff_type` assignment on acetone (`C=O` carbon → type 3, carbonyl oxygen → type 7).
2. **Runtime encapsulation guard** — replaces `mol._adjacency` with a `Guard` object that raises `AttributeError` on `[key]` subscript but allows `.get()` (used internally by `get_neighbor_bonds()`). Confirms no violation remains at runtime.
3. **Static source check** — asserts `_adjacency[` does not appear anywhere in `hand_coded.py`.

All 3 tests pass locally. The `testing/` directory is `.gitignore`d per repository convention, so tests are not included in this commit. Happy to add them to a `tests/` directory if preferred.

## Why This Matters

This decouples `HandCodedAtomTyper` from `Molecule`'s internal storage, enabling future graph backend changes (e.g. `scipy.sparse` adjacency for protein-scale molecules) without breaking the MMFF94 pipeline. It also sets the correct pattern for the upcoming `SmartsAtomTyper` (Phase 2).
